### PR TITLE
v0.2.2 : Bugfixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-json
+      - id: check-xml
+      - id: check-merge-conflict
+      - id: debug-statements
+
+  - repo: https://github.com/ambv/black
+    rev: 21.7b0
+    hooks:
+      - id: black
+        language_version: python3.11
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies: [flake8-bugbear==21.4.3, flake8-comprehensions==3.6.1]
+
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.1.1
+    hooks:
+      - id: pydocstyle
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.0
+    hooks:
+      - id: bandit
+        args: [--skip B404]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.910
+    hooks:
+      - id: mypy
+        args: [--ignore-missing-imports]
+
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint
+        entry: pylint
+        language: system
+        types: [python]
+
+  # - repo: https://github.com/pycqa/isort
+  #   rev: 5.11.2
+  #   hooks:
+  #     - id: isort
+  #       name: isort (python)
+  #       args: [--profile black]
+
+  # - repo: https://github.com/psf/black
+  #   rev: 20.8b1
+  #   hooks:
+  #     - id: black
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.6.0
+    hooks:
+    -   id: pyupgrade

--- a/commandeft/__init__.py
+++ b/commandeft/__init__.py
@@ -1,0 +1,2 @@
+class CommandeftException(Exception):
+    pass

--- a/commandeft/constants/config_constants.py
+++ b/commandeft/constants/config_constants.py
@@ -1,0 +1,16 @@
+REQUIRED_KEYS: list[str] = ["model", "temperature", "max_tokens", "accept_command_behavior"]
+
+TEMPERATURE = "temperature"
+MAX_TOKENS = "max_tokens"
+MODEL = "model"
+API_KEY = "api_key"
+ACCEPT_COMMAND_BEHAVIOR = "accept_command_behavior"
+GPT_3_5_TURBO = "gpt-3.5-turbo"
+GPT4 = "gpt4"
+
+
+MODELS_LIST: list[str] = [GPT_3_5_TURBO, GPT4]
+MODELS_MAX_TOKENS: dict[str, int] = {GPT_3_5_TURBO: 4096, GPT4: 2048}
+COMMAND_BEHAVIOURS: list[str] = ["run", "copy"]
+
+

--- a/commandeft/constants/consts.py
+++ b/commandeft/constants/consts.py
@@ -1,15 +1,14 @@
-import os
+from pathlib import Path
 
+CONFIG_FILE_PATH: Path = Path.home() / ".commandeft" / "config"
 
-CONFIG_FILE_PATH = os.path.expanduser("~/.commandeft/config")
-
-init_messages = [
+init_messages: list[str] = [
     "What mischief are we up to now?\n Describe the command you're concocting:",
     "Oh no, caught in another coding conundrum?\n Share the details:",
     "Here to save the day!\n Enlighten me with the command you're grappling with:",
     "When your coding journey hits a snag,\n Describe the task that makes you sag:",
     "No shame in seeking guidance.\n What command do you need a helping hand with?:",
-    "Trouble seems to find you often.\ nReveal the command conundrum you're facing now:",
+    "Trouble seems to find you often.\n Reveal the command conundrum you're facing now:",
     "We all need a helping hand sometimes.\n Describe the command that has you reaching out for support:",
     "In a pickle again, I see?\n Describe the trouble you're in and let's work it out together:",
     "Brave adventurer, share the quest for the command you seek and I shall guide you through:",
@@ -27,7 +26,7 @@ init_messages = [
     "In the digital realm, where all devs cry,\n A prompt for support, can't be denied!",
 ]
 
-fail_messages = [
+fail_messages: list[str] = [
     "Oh well, maybe next time!",
     "Better luck next time!",
     "Didn't quite get it this time huh?",
@@ -41,7 +40,7 @@ fail_messages = [
 ]
 
 # pylint: disable=anomalous-backslash-in-string
-COMMANDEFT_ASCII_DESC = """
+COMMANDEFT_ASCII_DESC: str = """
    ___                           ___       __ _   
   / __|___ _ __  _ __  __ _ _ _ |   \ ___ / _| |_ 
  | (__/ _ | '  \| '  \/ _` | ' \| |) / -_|  _|  _|
@@ -52,7 +51,7 @@ COMMANDEFT_ASCII_DESC = """
 
 """
 
-COMMANDEFT_NORMAL_DESC = """
+COMMANDEFT_NORMAL_DESC: str = """
 --- CommanDeft ---
 A simple Python CLI for generating shell commands using OpenAI's chat models.
 Prompt, Generate, Dominate! 

--- a/commandeft/core/cli.py
+++ b/commandeft/core/cli.py
@@ -1,22 +1,21 @@
-import os
 import shutil
 import json
 from importlib.metadata import version
 import click
 import pyperclip
 
-
 from commandeft.constants.consts import COMMANDEFT_ASCII_DESC, COMMANDEFT_NORMAL_DESC, CONFIG_FILE_PATH
 from commandeft.core.decision import decide_and_apply_action
 from commandeft.core.generation import generate_command
 from commandeft.util.config_util import validate_configuration
 from commandeft.util.interactive_util import get_configuration_answers, get_prompt
+from commandeft import CommandeftException
 
 COMMANDEFT_DESCRIPTION = COMMANDEFT_ASCII_DESC if shutil.get_terminal_size((80, 20)).columns >= 50 else COMMANDEFT_NORMAL_DESC
 
 
 class CustomCommand(click.Command):
-    def get_help(self, ctx):
+    def get_help(self, ctx: click.Context):
         # Get the default help message
         help_message = super().get_help(ctx)
 
@@ -27,8 +26,8 @@ class CustomCommand(click.Command):
         return custom_usage + help_message
 
 
-def configuration_mode():
-    if os.path.exists(CONFIG_FILE_PATH):
+def configuration_mode() -> None:
+    if CONFIG_FILE_PATH.exists():
         click.confirm(
             "Warning: Running the configuration flow will overwrite your previous configuration. \nAre you sure you want to continue?",
             abort=True,
@@ -37,7 +36,7 @@ def configuration_mode():
     answers = get_configuration_answers()
 
     # Save the configuration options to the file
-    os.makedirs(os.path.dirname(CONFIG_FILE_PATH), exist_ok=True)
+    CONFIG_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
     with open(CONFIG_FILE_PATH, "w", encoding="utf-8") as config_file:
         json.dump(answers, config_file)
 
@@ -48,11 +47,8 @@ def configuration_mode():
     )
 
 
-def interactive_mode():
-    if not os.path.exists(CONFIG_FILE_PATH):
-        configuration_mode()
-    else:
-        validate_configuration()
+def interactive_mode() -> None:
+    __initialize()
     user_prompt = get_prompt()
     command = generate_command(user_prompt)
     click.echo(click.style("> " + command, fg="green"))
@@ -60,16 +56,27 @@ def interactive_mode():
     decide_and_apply_action(command)
 
 
-def prompt_in_line(prompt):
-    if not os.path.exists(CONFIG_FILE_PATH):
-        configuration_mode()
-    else:
-        validate_configuration()
+def prompt_in_line(prompt: str) -> None:
+    __initialize()
     command = generate_command(prompt)
     click.echo(click.style("> " + command, fg="green"))
     pyperclip.copy(command)
     click.echo("Command copied to clipboard!")
 
 
-def print_version():
+def print_version() -> None:
     click.echo(version("commandeft"))
+
+
+def __initialize():
+    if not CONFIG_FILE_PATH.exists():
+        configuration_mode()
+    else:
+        try:
+            validate_configuration()
+        except CommandeftException as e:
+            click.echo(click.style(f"An error occurred: {str(e)}", fg="red"))
+            click.echo("commandeft needs to be reconfigured")
+            CONFIG_FILE_PATH.unlink()
+            configuration_mode()
+            

--- a/commandeft/core/decision.py
+++ b/commandeft/core/decision.py
@@ -8,7 +8,7 @@ from commandeft.util.config_util import get_configuration
 from commandeft.util.interactive_util import get_decision
 
 
-def decide_and_apply_action(command):
+def decide_and_apply_action(command: str) -> None:
     accept_command_behavior = get_configuration("accept_command_behavior")
 
     decision = get_decision(accept_command_behavior)

--- a/commandeft/core/generation.py
+++ b/commandeft/core/generation.py
@@ -1,6 +1,8 @@
-import sys
-import click
 import guidance
+import tiktoken
+from openai.error import InvalidRequestError
+from commandeft import CommandeftException
+from commandeft.constants.config_constants import API_KEY, MAX_TOKENS, MODEL, MODELS_MAX_TOKENS, TEMPERATURE
 
 from commandeft.util.gen_util import (
     get_current_shell,
@@ -10,17 +12,18 @@ from commandeft.util.gen_util import (
 from commandeft.util.config_util import get_configuration
 
 
-def generate_command(user_prompt):
-    api_key = get_configuration("api_key")
+def generate_command(user_prompt: str) -> str:
+    model = get_configuration(MODEL)
+    api_key = get_configuration(API_KEY)
     llm = guidance.llms.OpenAI(
-        get_configuration("model"),
+        model=model,
         api_key=api_key,
     )
 
-    current_shell = get_current_shell()
-    current_os = get_current_os()
-    temperature = get_configuration("temperature")
-    max_tokens = get_configuration("max_tokens")
+    current_shell_conf = get_current_shell()
+    current_os_conf = get_current_os()
+    temperature_conf = get_configuration(TEMPERATURE)
+    max_tokens_conf = get_configuration(MAX_TOKENS)
 
     template_default = """{{#system~}}
         Assume the role of a shell scripting expert with the given specifications:
@@ -36,23 +39,40 @@ def generate_command(user_prompt):
         {{~/assistant}}"""
 
     # pylint: disable=not-callable
-    program = guidance(
-        template_default,
-        llm=llm,
-    )
 
-    res = program(
-        user_prompt=user_prompt,
-        chosen_temperature=temperature,
-        current_shell=current_shell,
-        current_os=current_os,
-        # 55 is the number of tokens consumed by the guided prompt
-        chosen_max_tokens=max_tokens + 55,
-        caching=True,
-    )
     try:
+        program = guidance(
+           template_default,
+            llm=llm,
+        )
+        prompt_tokens: int = __num_tokens_from_string(user_prompt, model)
+        model_max_token_limit = MODELS_MAX_TOKENS[model]
+        if prompt_tokens + 55 > model_max_token_limit or prompt_tokens + 55 > max_tokens_conf:
+            raise CommandeftException(
+                f"""Your prompt is too long ({prompt_tokens} tokens). The maximum number of tokens for model {model} is {model_max_token_limit}.
+                Your max_tokens configuration is {max_tokens_conf}. Please shorten your prompt."""
+            )
+        chosen_max_tokens = max_tokens_conf + 55 + prompt_tokens
+            
+
+        res = program(
+            user_prompt=user_prompt,
+            chosen_temperature=temperature_conf,
+            current_shell=current_shell_conf,
+            current_os=current_os_conf,
+            # 55 is the number of tokens consumed by the guided prompt
+            chosen_max_tokens=chosen_max_tokens,
+            caching=True,
+        )
         command = parse_code_block(res["result"])
         return command
     except ValueError:
-        click.echo(click.style(res["result"].replace(". ", ".\n"), fg="red"))
-        sys.exit(1)
+        raise CommandeftException(res["result"].replace(". ", ".\n"))
+    except InvalidRequestError as e:
+        raise CommandeftException("OpenAI API Error: " + str(e))
+
+def __num_tokens_from_string(string: str, model) -> int:
+    """Returns the number of tokens in a text string."""
+    encoding = tiktoken.encoding_for_model(model)
+    num_tokens = len(encoding.encode(string))
+    return num_tokens

--- a/commandeft/main.py
+++ b/commandeft/main.py
@@ -2,14 +2,6 @@ import sys
 import click
 
 from commandeft.core.cli import CustomCommand, configuration_mode, print_version, prompt_in_line, interactive_mode
-def custom_exception_handler(exc_value):
-    # Handle the exception
-    click.echo(click.style(f"An error occurred:{str(exc_value),}", fg="red"))
-    sys.exit(1)
-
-
-sys.excepthook = custom_exception_handler
-
 
 @click.command(cls=CustomCommand)
 @click.help_option("-h", "--help")

--- a/commandeft/main.py
+++ b/commandeft/main.py
@@ -2,8 +2,6 @@ import sys
 import click
 
 from commandeft.core.cli import CustomCommand, configuration_mode, print_version, prompt_in_line, interactive_mode
-
-
 def custom_exception_handler(exc_value):
     # Handle the exception
     click.echo(click.style(f"An error occurred:{str(exc_value),}", fg="red"))
@@ -19,7 +17,7 @@ sys.excepthook = custom_exception_handler
 @click.option("-c", "--configure", help="Configure commandeft", is_flag=True)
 @click.option("-i", "--interactive", help="Run in interactive mode", is_flag=True)
 @click.option("-p", "--prompt", help="Specify your prompt inline")
-def commandeft(version, configure, interactive, prompt):
+def commandeft(version: bool, configure: bool, interactive: bool, prompt: str):
     if version:
         print_version()
     elif configure:
@@ -33,4 +31,7 @@ def commandeft(version, configure, interactive, prompt):
 
 
 if __name__ == "__main__":
-    commandeft()  # pylint: disable=no-value-for-parameter
+    try:
+        commandeft()  # pylint: disable=no-value-for-parameter
+    except Exception as e:
+        click.echo(click.style(f"An error occurred: {str(e)}", fg="red"))

--- a/commandeft/util/config_util.py
+++ b/commandeft/util/config_util.py
@@ -4,16 +4,9 @@ from pathlib import Path
 from commandeft.constants.config_constants import (REQUIRED_KEYS, TEMPERATURE, 
                                                    MAX_TOKENS, MODEL, 
                                                    ACCEPT_COMMAND_BEHAVIOR, 
-                                                   GPT_3_5_TURBO, GPT4, 
                                                    MODELS_LIST, MODELS_MAX_TOKENS,
                                                    COMMAND_BEHAVIOURS)
 from commandeft import CommandeftException
-
-class Configuration(str):
-    def __eq__(self, other):
-        allowed_values = ["model", "temperature", "max_tokens"]
-        return str(self) in allowed_values
-
 
 def get_configuration(config_property):
     if CONFIG_FILE_PATH.exists():

--- a/pdm.lock
+++ b/pdm.lock
@@ -58,6 +58,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.3.1"
+requires_python = ">=3.6.1"
+summary = "Validate configuration and produce human readable error messages."
+
+[[package]]
 name = "charset-normalizer"
 version = "3.1.0"
 requires_python = ">=3.7.0"
@@ -94,6 +100,17 @@ requires_python = ">=3"
 summary = "Disk Cache -- Disk and file backed persistent cache."
 
 [[package]]
+name = "distlib"
+version = "0.3.6"
+summary = "Distribution utilities"
+
+[[package]]
+name = "filelock"
+version = "3.12.2"
+requires_python = ">=3.7"
+summary = "A platform independent file lock."
+
+[[package]]
 name = "frozenlist"
 version = "1.3.3"
 requires_python = ">=3.7"
@@ -127,6 +144,12 @@ dependencies = [
     "requests",
     "tiktoken>=0.3",
 ]
+
+[[package]]
+name = "identify"
+version = "2.5.24"
+requires_python = ">=3.7"
+summary = "File identification library for Python"
 
 [[package]]
 name = "idna"
@@ -165,6 +188,15 @@ name = "nest-asyncio"
 version = "1.5.6"
 requires_python = ">=3.5"
 summary = "Patch asyncio to allow nested event loops"
+
+[[package]]
+name = "nodeenv"
+version = "1.8.0"
+requires_python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+summary = "Node.js virtual environment builder"
+dependencies = [
+    "setuptools",
+]
 
 [[package]]
 name = "numpy"
@@ -211,6 +243,19 @@ name = "platformdirs"
 version = "3.5.3"
 requires_python = ">=3.7"
 summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+
+[[package]]
+name = "pre-commit"
+version = "3.3.3"
+requires_python = ">=3.8"
+summary = "A framework for managing and maintaining multi-language pre-commit hooks."
+dependencies = [
+    "cfgv>=2.0.0",
+    "identify>=1.0.0",
+    "nodeenv>=0.11.1",
+    "pyyaml>=5.1",
+    "virtualenv>=20.10.0",
+]
 
 [[package]]
 name = "prettytable"
@@ -270,6 +315,12 @@ version = "1.8.2"
 summary = "A cross-platform clipboard module for Python. (Only handles plain text for now.)"
 
 [[package]]
+name = "pyyaml"
+version = "6.0"
+requires_python = ">=3.6"
+summary = "YAML parser and emitter for Python"
+
+[[package]]
 name = "regex"
 version = "2023.6.3"
 requires_python = ">=3.6"
@@ -286,6 +337,12 @@ dependencies = [
     "idna<4,>=2.5",
     "urllib3<3,>=1.21.1",
 ]
+
+[[package]]
+name = "setuptools"
+version = "67.8.0"
+requires_python = ">=3.7"
+summary = "Easily download, build, install, upgrade, and uninstall Python packages"
 
 [[package]]
 name = "six"
@@ -319,6 +376,17 @@ requires_python = ">=3.7"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
 
 [[package]]
+name = "virtualenv"
+version = "20.23.0"
+requires_python = ">=3.7"
+summary = "Virtual Python Environment builder"
+dependencies = [
+    "distlib<1,>=0.3.6",
+    "filelock<4,>=3.11",
+    "platformdirs<4,>=3.2",
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.2.6"
 summary = "Measures the displayed width of unicode strings in a terminal"
@@ -337,7 +405,7 @@ dependencies = [
 lock_version = "4.2"
 cross_platform = true
 groups = ["default"]
-content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4df2e0e8"
+content_hash = "sha256:ea483e1e274d7a96e78303453320056a949be2b8a560e05b5b218a7125202488"
 
 [metadata.files]
 "aiohttp 3.8.4" = [
@@ -515,6 +583,10 @@ content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4
     {url = "https://files.pythonhosted.org/packages/f9/96/fc9e118c47b7adc45a0676f413b4a47554e5f3b6c99b8607ec9726466ef1/cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
     {url = "https://files.pythonhosted.org/packages/ff/fe/ac46ca7b00e9e4f9c62e7928a11bc9227c86e2ff43526beee00cdfb4f0e8/cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
 ]
+"cfgv 3.3.1" = [
+    {url = "https://files.pythonhosted.org/packages/6d/82/0a0ebd35bae9981dea55c06f8e6aaf44a49171ad798795c72c6f64cba4c2/cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
+    {url = "https://files.pythonhosted.org/packages/c4/bf/d0d622b660d414a47dc7f0d303791a627663f554345b21250e39e7acb48b/cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},
+]
 "charset-normalizer 3.1.0" = [
     {url = "https://files.pythonhosted.org/packages/00/47/f14533da238134f5067fb1d951eb03d5c4be895d6afb11c7ebd07d111acb/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28"},
     {url = "https://files.pythonhosted.org/packages/01/c7/0407de35b70525dba2a58a2724a525cf882ee76c3d2171d834463c5d2881/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb"},
@@ -625,6 +697,14 @@ content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4
     {url = "https://files.pythonhosted.org/packages/1c/87/5f5efc3606766a8a1621fecb8b8ca2111d1dad4b9b8a631579f070d47939/diskcache-5.6.1-py3-none-any.whl", hash = "sha256:558c6a2d5d7c721bb00e40711803d6804850c9f76c426ed81ecc627fe9d2ce2d"},
     {url = "https://files.pythonhosted.org/packages/7b/65/5d93ced326fe943ca8970848fd0522be81868a9afa169a22fd19cd737d5c/diskcache-5.6.1.tar.gz", hash = "sha256:e4c978532feff5814c4cc00fe1e11e40501985946643d73220d41ee7737c72c3"},
 ]
+"distlib 0.3.6" = [
+    {url = "https://files.pythonhosted.org/packages/58/07/815476ae605bcc5f95c87a62b95e74a1bce0878bc7a3119bc2bf4178f175/distlib-0.3.6.tar.gz", hash = "sha256:14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"},
+    {url = "https://files.pythonhosted.org/packages/76/cb/6bbd2b10170ed991cf64e8c8b85e01f2fb38f95d1bc77617569e0b0b26ac/distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},
+]
+"filelock 3.12.2" = [
+    {url = "https://files.pythonhosted.org/packages/00/0b/c506e9e44e4c4b6c89fcecda23dc115bf8e7ff7eb127e0cb9c114cbc9a15/filelock-3.12.2.tar.gz", hash = "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81"},
+    {url = "https://files.pythonhosted.org/packages/00/45/ec3407adf6f6b5bf867a4462b2b0af27597a26bd3cd6e2534cb6ab029938/filelock-3.12.2-py3-none-any.whl", hash = "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"},
+]
 "frozenlist 1.3.3" = [
     {url = "https://files.pythonhosted.org/packages/01/a3/a3c18bfd7bd2a56831b985140f98eb6dda684a2d8b2a54b1077b45c7f9d9/frozenlist-1.3.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23d16d9f477bb55b6154654e0e74557040575d9d19fe78a161bd33d7d76808e8"},
     {url = "https://files.pythonhosted.org/packages/03/00/febbfd2ec244a0f91707bd879afe6aa278e337dc41cd9d0d25260e6da38e/frozenlist-1.3.3-cp38-cp38-win_amd64.whl", hash = "sha256:7f44e24fa70f6fbc74aeec3e971f60a14dde85da364aa87f15d1be94ae75aeef"},
@@ -708,6 +788,10 @@ content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4
 "guidance 0.0.61" = [
     {url = "https://files.pythonhosted.org/packages/17/0a/e329a958627a5d329c53b49c97ccd1832153659f2e514900482a07384955/guidance-0.0.61-py3-none-any.whl", hash = "sha256:311e1e7192b82e40b81db9ffdd725053669d93546160f2d55b26be077295f050"},
     {url = "https://files.pythonhosted.org/packages/b7/c8/2e8eee6dbd233fba96348a0ed83a51410e7d09c8c7dc2abfdbcd42cfb172/guidance-0.0.61.tar.gz", hash = "sha256:365ae9e61eec1692e536bda1d47f6fbdd182a9163641980dd519ff5833b631fe"},
+]
+"identify 2.5.24" = [
+    {url = "https://files.pythonhosted.org/packages/4f/fd/2c46fba2bc032ba4c970bb8de59d25187087d7138a0ebf7c1dcc91d94f01/identify-2.5.24-py2.py3-none-any.whl", hash = "sha256:986dbfb38b1140e763e413e6feb44cd731faf72d1909543178aa79b0e258265d"},
+    {url = "https://files.pythonhosted.org/packages/c4/f8/498e13e408d25ee6ff04aa0acbf91ad8e9caae74be91720fc0e811e649b7/identify-2.5.24.tar.gz", hash = "sha256:0aac67d5b4812498056d28a9a512a483f5085cc28640b02b258a59dac34301d4"},
 ]
 "idna 3.4" = [
     {url = "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
@@ -801,6 +885,10 @@ content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4
     {url = "https://files.pythonhosted.org/packages/35/76/64c51c1cbe704ad79ef6ec82f232d1893b9365f2ff194111787dc91b004f/nest_asyncio-1.5.6.tar.gz", hash = "sha256:d267cc1ff794403f7df692964d1d2a3fa9418ffea2a3f6859a439ff482fef290"},
     {url = "https://files.pythonhosted.org/packages/e9/1a/6dd9ec31cfdb34cef8fea0055b593ee779a6f63c8e8038ad90d71b7f53c0/nest_asyncio-1.5.6-py3-none-any.whl", hash = "sha256:b9a953fb40dceaa587d109609098db21900182b16440652454a146cffb06e8b8"},
 ]
+"nodeenv 1.8.0" = [
+    {url = "https://files.pythonhosted.org/packages/1a/e6/6d2ead760a9ddb35e65740fd5a57e46aadd7b0c49861ab24f94812797a1c/nodeenv-1.8.0-py2.py3-none-any.whl", hash = "sha256:df865724bb3c3adc86b3876fa209771517b0cfe596beff01a92700e0e8be4cec"},
+    {url = "https://files.pythonhosted.org/packages/48/92/8e83a37d3f4e73c157f9fcf9fb98ca39bd94701a469dc093b34dca31df65/nodeenv-1.8.0.tar.gz", hash = "sha256:d51e0c37e64fbf47d017feac3145cdbb58836d7eee8c6f6d3b6880c5456227d2"},
+]
 "numpy 1.24.3" = [
     {url = "https://files.pythonhosted.org/packages/0d/43/643629a4a278b4815541c7d69856c07ddb0e99bdc62b43538d3751eae2d8/numpy-1.24.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4719d5aefb5189f50887773699eaf94e7d1e02bf36c1a9d353d9f46703758ca4"},
     {url = "https://files.pythonhosted.org/packages/15/b8/cbe1750b9ec78062e5a00ef39ff8bdf189ce753b411b6b35931ababaee47/numpy-1.24.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:35400e6a8d102fd07c71ed7dcadd9eb62ee9a6e84ec159bd48c28235bbb0f8e4"},
@@ -851,6 +939,10 @@ content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4
     {url = "https://files.pythonhosted.org/packages/6d/1a/96efea7b36835ce89911d7813fe68f5b1db7ecae4023bf209a7aeba93017/platformdirs-3.5.3-py3-none-any.whl", hash = "sha256:0ade98a4895e87dc51d47151f7d2ec290365a585151d97b4d8d6312ed6132fed"},
     {url = "https://files.pythonhosted.org/packages/d2/5d/29eed8861e07378ef46e956650615a9677f8f48df7911674f923236ced2b/platformdirs-3.5.3.tar.gz", hash = "sha256:e48fabd87db8f3a7df7150a4a5ea22c546ee8bc39bc2473244730d4b56d2cc4e"},
 ]
+"pre-commit 3.3.3" = [
+    {url = "https://files.pythonhosted.org/packages/35/0e/564c71fe3cdf59a4acaaccaea354d066e5d9044eba564dac070bb2075432/pre_commit-3.3.3.tar.gz", hash = "sha256:a2256f489cd913d575c145132ae196fe335da32d91a8294b7afe6622335dd023"},
+    {url = "https://files.pythonhosted.org/packages/e3/b7/1d145c985d8be9729672a45b8b8113030ad60dff45dec592efc4e5f5897a/pre_commit-3.3.3-py2.py3-none-any.whl", hash = "sha256:10badb65d6a38caff29703362271d7dca483d01da88f9d7e05d0b97171c136cb"},
+]
 "prettytable 3.7.0" = [
     {url = "https://files.pythonhosted.org/packages/7a/cd/bec5850e23eb005c6fe30fe4c26bafd9a07b3d2524771f22a0fa01270078/prettytable-3.7.0-py3-none-any.whl", hash = "sha256:f4aaf2ed6e6062a82fd2e6e5289bbbe705ec2788fe401a3a1f62a1cea55526d2"},
     {url = "https://files.pythonhosted.org/packages/95/8d/f6b4448e386eb1382a99cbceabe3899f3aa431992582cc90496843548303/prettytable-3.7.0.tar.gz", hash = "sha256:ef8334ee40b7ec721651fc4d37ecc7bb2ef55fde5098d994438f0dfdaa385c0c"},
@@ -877,6 +969,48 @@ content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4
 ]
 "pyperclip 1.8.2" = [
     {url = "https://files.pythonhosted.org/packages/a7/2c/4c64579f847bd5d539803c8b909e54ba087a79d01bb3aba433a95879a6c5/pyperclip-1.8.2.tar.gz", hash = "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"},
+]
+"pyyaml 6.0" = [
+    {url = "https://files.pythonhosted.org/packages/02/25/6ba9f6bb50a3d4fbe22c1a02554dc670682a07c8701d1716d19ddea2c940/PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {url = "https://files.pythonhosted.org/packages/08/f4/ffa743f860f34a5e8c60abaaa686f82c9ac7a2b50e5a1c3b1eb564d59159/PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {url = "https://files.pythonhosted.org/packages/0f/93/5f81d1925ce3b531f5ff215376445ec220887cd1c9a8bde23759554dbdfd/PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {url = "https://files.pythonhosted.org/packages/12/fc/a4d5a7554e0067677823f7265cb3ae22aed8a238560b5133b58cda252dad/PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {url = "https://files.pythonhosted.org/packages/21/67/b42191239c5650c9e419c4a08a7a022bbf1abf55b0391c380a72c3af5462/PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {url = "https://files.pythonhosted.org/packages/2e/b3/13dfd4eeb5e4b2d686b6d1822b40702e991bf3a4194ca5cbcce8d43749db/PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {url = "https://files.pythonhosted.org/packages/36/2b/61d51a2c4f25ef062ae3f74576b01638bebad5e045f747ff12643df63844/PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+    {url = "https://files.pythonhosted.org/packages/44/e5/4fea13230bcebf24b28c0efd774a2dd65a0937a2d39e94a4503438b078ed/PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {url = "https://files.pythonhosted.org/packages/4d/7d/c2ab8da648cd2b937de11fb35649b127adab4851cbeaf5fd9b60a2dab0f7/PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {url = "https://files.pythonhosted.org/packages/55/e3/507a92589994a5b3c3d7f2a7a066339d6ff61c5c839bae56f7eff03d9c7b/PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {url = "https://files.pythonhosted.org/packages/56/8f/e8b49ad21d26111493dc2d5cae4d7efbd0e2e065440665f5023515f87f64/PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {url = "https://files.pythonhosted.org/packages/59/00/30e33fcd2a4562cd40c49c7740881009240c5cbbc0e41ca79ca4bba7c24b/PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
+    {url = "https://files.pythonhosted.org/packages/5e/f4/7b4bb01873be78fc9fde307f38f62e380b7111862c165372cf094ca2b093/PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {url = "https://files.pythonhosted.org/packages/63/6b/f5dc7942bac17192f4ef00b2d0cdd1ae45eea453d05c1944c0573debe945/PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {url = "https://files.pythonhosted.org/packages/67/d4/b95266228a25ef5bd70984c08b4efce2c035a4baa5ccafa827b266e3dc36/PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {url = "https://files.pythonhosted.org/packages/68/3f/c027422e49433239267c62323fbc6320d6ac8d7d50cf0cb2a376260dad5f/PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {url = "https://files.pythonhosted.org/packages/6c/3d/524c642f3db37e7e7ab8d13a3f8b0c72d04a619abc19100097d987378fc6/PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {url = "https://files.pythonhosted.org/packages/74/68/3c13deaa496c14a030c431b7b828d6b343f79eb241b4848c7918091a64a2/PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {url = "https://files.pythonhosted.org/packages/77/da/e845437ffe0dffae4e7562faf23a4f264d886431c5d2a2816c853288dc8e/PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {url = "https://files.pythonhosted.org/packages/7f/d9/6a0d14ac8d3b5605dc925d177c1d21ee9f0b7b39287799db1e50d197b2f4/PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {url = "https://files.pythonhosted.org/packages/81/59/561f7e46916b78f3c4cab8d0c307c81656f11e32c846c0c97fda0019ed76/PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {url = "https://files.pythonhosted.org/packages/89/26/0bfd7b756b34c68f8fd158b7bc762b6b1705fc1b3cebf4cdbb53fd9ea75b/PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {url = "https://files.pythonhosted.org/packages/91/49/d46d7b15cddfa98533e89f3832f391aedf7e31f37b4d4df3a7a7855a7073/PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {url = "https://files.pythonhosted.org/packages/9d/f6/7e91fbb58c9ee528759aea5892e062cccb426720c5830ddcce92eba00ff1/PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {url = "https://files.pythonhosted.org/packages/a4/ba/e508fc780e3c94c12753a54fe8f74de535741a10d33b29a576a9bec03500/PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {url = "https://files.pythonhosted.org/packages/a4/e6/4d7a01bc0730c8f958a62d6a4c4f3df23b6139ad68c132b168970d84f192/PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {url = "https://files.pythonhosted.org/packages/a8/32/1bbe38477fb23f1d83041fefeabf93ef1cd6f0efcf44c221519507315d92/PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {url = "https://files.pythonhosted.org/packages/a8/5b/c4d674846ea4b07ee239fbf6010bcc427c4e4552ba5655b446e36b9a40a7/PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {url = "https://files.pythonhosted.org/packages/b3/85/79b9e5b4e8d3c0ac657f4e8617713cca8408f6cdc65d2ee6554217cedff1/PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {url = "https://files.pythonhosted.org/packages/b7/09/2f6f4851bbca08642fef087bade095edc3c47f28d1e7bff6b20de5262a77/PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {url = "https://files.pythonhosted.org/packages/cb/5f/05dd91f5046e2256e35d885f3b8f0f280148568f08e1bf20421887523e9a/PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {url = "https://files.pythonhosted.org/packages/d1/c0/4fe04181b0210ee2647cfbb89ecd10a36eef89f10d8aca6a192c201bbe58/PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {url = "https://files.pythonhosted.org/packages/d7/42/7ad4b6d67a16229496d4f6e74201bdbebcf4bc1e87d5a70c9297d4961bd2/PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {url = "https://files.pythonhosted.org/packages/db/4e/74bc723f2d22677387ab90cd9139e62874d14211be7172ed8c9f9a7c81a9/PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {url = "https://files.pythonhosted.org/packages/df/75/ee0565bbf65133e5b6ffa154db43544af96ea4c42439e6b58c1e0eb44b4e/PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {url = "https://files.pythonhosted.org/packages/eb/5f/6e6fe6904e1a9c67bc2ca5629a69e7a5a0b17f079da838bab98a1e548b25/PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {url = "https://files.pythonhosted.org/packages/ef/ad/b443cce94539e57e1a745a845f95c100ad7b97593d7e104051e43f730ecd/PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {url = "https://files.pythonhosted.org/packages/f5/6f/b8b4515346af7c33d3b07cd8ca8ea0700ca72e8d7a750b2b87ac0268ca4e/PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {url = "https://files.pythonhosted.org/packages/f8/54/799b059314b13e1063473f76e908f44106014d18f54b16c83a16edccd5ec/PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {url = "https://files.pythonhosted.org/packages/fc/48/531ecd926fe0a374346dd811bf1eda59a95583595bb80eadad511f3269b8/PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
 ]
 "regex 2023.6.3" = [
     {url = "https://files.pythonhosted.org/packages/05/bb/72408a1c713e470abe144bce3622d7b1feadd74fab1f9c7fc5e1e4d5917b/regex-2023.6.3-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:cf67ca618b4fd34aee78740bea954d7c69fdda419eb208c2c0c7060bb822d747"},
@@ -972,6 +1106,10 @@ content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4
     {url = "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
     {url = "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
 ]
+"setuptools 67.8.0" = [
+    {url = "https://files.pythonhosted.org/packages/03/20/630783571e76e5fa5f3e9f29398ca3ace377207b8196b54e0ffdf09f12c1/setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
+    {url = "https://files.pythonhosted.org/packages/f5/2c/074ab1c5be9c7d523d8d6d69d1f46f450fe7f11713147dc9e779aa4ca4ea/setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
+]
 "six 1.16.0" = [
     {url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
     {url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1014,6 +1152,10 @@ content_hash = "sha256:c61fc7b7552f364da44096d950ef7f41b79ba99d7c75c59bdb48d55f4
 "urllib3 2.0.2" = [
     {url = "https://files.pythonhosted.org/packages/4b/1d/f8383ef593114755429c307449e7717b87044b3bcd5f7860b89b1f759e34/urllib3-2.0.2-py3-none-any.whl", hash = "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"},
     {url = "https://files.pythonhosted.org/packages/fb/c0/1abba1a1233b81cf2e36f56e05194f5e8a0cec8c03c244cab56cc9dfb5bd/urllib3-2.0.2.tar.gz", hash = "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc"},
+]
+"virtualenv 20.23.0" = [
+    {url = "https://files.pythonhosted.org/packages/d6/37/3ff25b2ad0d51cfd752dc68ee0ad4387f058a5ceba4d89b47ac478de3f59/virtualenv-20.23.0.tar.gz", hash = "sha256:a85caa554ced0c0afbd0d638e7e2d7b5f92d23478d05d17a76daeac8f279f924"},
+    {url = "https://files.pythonhosted.org/packages/f1/0a/18755fa6aec794fd539b050beeaa905fa5c77c64356aa8bdecb62c01581a/virtualenv-20.23.0-py3-none-any.whl", hash = "sha256:6abec7670e5802a528357fdc75b26b9f57d5d92f29c5462ba0fbe45feacc685e"},
 ]
 "wcwidth 0.2.6" = [
     {url = "https://files.pythonhosted.org/packages/20/f4/c0584a25144ce20bfcf1aecd041768b8c762c1eb0aa77502a3f0baa83f11/wcwidth-0.2.6-py2.py3-none-any.whl", hash = "sha256:795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "wcwidth==0.2.6",
     "yarl<2.0,>=1.0",
     "InquirerPy>=0.3.4",
+    "pre-commit>=3.3.3",
 ]
 license = {text = "MIT"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "commandeft"
-version = "0.2.1"
+version = "0.2.2"
 description = "CommanDeft is a CLI tool that converts natural language prompts into executable commands or scripts using OpenAI's chat models."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
v0.2.2 : Mainly bugfixes. No functionality or API changes.

Info:
- Use of custom exceptions
- Error handling for max_tokens and errors while reading configuration file
- put all commonly used strings in constants
- count number of tokens in user prompt
- use pathlib instead of os.path
- add types in function signatures
- replace sys.exit(1) with raise CommandeftException
- use pre-commit tool for improved maintainability of codebase